### PR TITLE
Add option to concatenate only new lines (exclude spaces)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SalesfOps",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "A collection of productivity micro-tools for operations teams, with a focus on Salesforce workflows",
   "keywords": [
     "salesforce",

--- a/src/commands/stringConcatenator.js
+++ b/src/commands/stringConcatenator.js
@@ -30,7 +30,7 @@ class StringConcatenatorCommand {
 
         this.window = createDarkWindow({
             width: 450,
-            height: 260,
+            height: 280,
             frame: false,
             resizable: false,
             alwaysOnTop: true

--- a/src/styles/dark-input.css
+++ b/src/styles/dark-input.css
@@ -89,6 +89,26 @@ html, body {
     color: #666666;
 }
 
+.checkbox-container {
+    margin-top: 12px;
+    margin-bottom: 8px;
+    display: flex;
+    align-items: center;
+}
+
+.checkbox-container input[type="checkbox"] {
+    width: 14px;
+    height: 14px;
+    margin-right: 8px;
+    accent-color: #9e0f9e;
+}
+
+.checkbox-container label {
+    font-size: 12px;
+    color: #888;
+    font-weight: normal;
+}
+
 /* Title and text */
 h1 {
     margin-bottom: 40px;

--- a/src/windows/id-concatenate.html
+++ b/src/windows/id-concatenate.html
@@ -16,16 +16,20 @@
             placeholder="Enter strings (separated by spaces or new lines)"
             autofocus
         ></textarea>
+        <div class="checkbox-container">
+            <input type="checkbox" id="newlines-only" name="newlines-only">
+            <label for="newlines-only">Split by newlines only (ignore spaces)</label>
+        </div>
         <div class="hint">
             Press <span class="key">↵</span> to concatenate or <span class="key">Esc</span> to cancel
         </div>
         <div id="success-message" class="success-message"></div>
-        <div id="result" class="result"></div>
-        
+        <div id="result" class="result"></div>  
     </div>
 
     <script>
         const textarea = document.getElementById('string-input');
+        const newlinesOnlyCheckbox = document.getElementById('newlines-only');
         const successMessage = document.getElementById('success-message');
         const resultDiv = document.getElementById('result');
 
@@ -34,10 +38,10 @@
             textarea.select();
         });
         
-
-        function concatenateStrings(input) {
+        function concatenateStrings(input, newlinesOnly) {
+            const separator = newlinesOnly ? /\n+/ : /[\s\n]+/;
             const strings = input
-                .split(/[\s\n]+/)
+                .split(separator)
                 .filter(s => s.trim())
                 .map(s => `'${s.trim()}'`);
             return `(${strings.join(', ')})`;
@@ -48,7 +52,8 @@
                 event.preventDefault();
                 const input = textarea.value.trim();
                 if (input) {
-                    const result = concatenateStrings(input);
+                    const newlinesOnly = newlinesOnlyCheckbox.checked;
+                    const result = concatenateStrings(input, newlinesOnly);
                     
                     await window.electronAPI.copyToClipboard(result);
                     


### PR DESCRIPTION
When concatenate Strings : 
- Add checkbox to let choose between concatenate strings with or without space char.

Option not checked : 

> 1234 4567
> 7889

Became : 
>('1234', '4567', '7889')

Option checked : 

> Michel letest
> Monique tamèrh

Became : 
>('Michel letest', 'Monique tamèrh')
