### PR TITLE
New command to use snippets and copy result in clipboard

### DIFF
--- a/main.js
+++ b/main.js
@@ -77,6 +77,7 @@ class Application {
         const customSearchActive = await this.settings.get('customSearchActive');
         const extractValueActive = await this.settings.get('extractValueActive');
         const updateValuesActive = await this.settings.get('updateValuesActive');
+        const snippetsActive = await this.settings.get('snippetsActive');
     
         if (openSalesforceIdActive) {
             menuItems.push({ 
@@ -131,6 +132,14 @@ class Application {
                 label: 'Select custom search',
                 click: () => this.commands.customSearch.createWindow(),
                 accelerator: await this.getShortcutLabel('customSearchShortcut')
+            });
+        }
+
+        if (snippetsActive) {
+            menuItems.push({
+                label: 'Insert Text Snippet',
+                click: () => this.commands.snippets.createWindow(),
+                accelerator: await this.getShortcutLabel('snippetsShortcut')
             });
         }
     

--- a/preload.js
+++ b/preload.js
@@ -25,4 +25,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     updateCsvValues: (options) => ipcRenderer.invoke('update-csv-values', options),
     restoreWindowSize: () => ipcRenderer.send('restore-window-size'),
     closeUpdateValues: () => ipcRenderer.send('close-update-values'),
+    copySnippetToClipboard: (text) => ipcRenderer.invoke('copy-snippet-to-clipboard', text),
+    getSnippets: () => ipcRenderer.invoke('get-snippets'),
+    copySnippetToClipboard: (text) => ipcRenderer.invoke('copy-snippet-to-clipboard', text),
+    closeSnippets: () => ipcRenderer.send('close-snippets'),
 });

--- a/settings.html
+++ b/settings.html
@@ -239,6 +239,42 @@
                     Add Custom Search
                 </button>
             </div>
+            <div class="section-divider">
+                <h2>Text Snippets</h2>
+            </div>
+
+            <div class="form-group shortcut-group">
+                <div class="shortcut-header">
+                    <div class="tooltip-container">
+                        <label for="snippetsShortcut">Text Snippets Shortcut</label>
+                        <span class="tooltip-icon">💡</span>
+                        <span class="tooltip-text">
+                            Access your text snippets. Configure frequently used text blocks that can be quickly copied to your clipboard. Choose a keyword and the corresponding text to copy.
+                        </span>
+                    </div>
+                    <div class="active-toggle">
+                        <input type="checkbox" 
+                               id="snippetsActive" 
+                               data-setting>
+                        <label for="snippetsActive">Active</label>
+                    </div>
+                </div>
+                <input type="text" 
+                       id="snippetsShortcut" 
+                       data-setting
+                       placeholder="CommandOrControl+Shift+T">
+                <small class="help-text">
+                    Quickly copy frequently used text snippets to clipboard
+                </small>    
+            </div>
+
+            <div class="snippets-container">
+                <label>Text Snippets</label>
+                <div id="snippets" class="snippets"></div>
+                <button type="button" class="secondary-button mt-4" onclick="addSnippet()">
+                    Add Snippet
+                </button>
+            </div>
 
             <div class="submit-container">
                 <div id="save-message" class="save-message"></div>
@@ -272,6 +308,21 @@
             </button>
         </div>
     </template>
+    <template id="snippetTemplate">
+        <div class="snippet-item">
+            <div class="form-group">
+                <label>Keyword</label>
+                <input type="text" class="snippet-keyword dark-input" required>
+            </div>
+            <div class="form-group">
+                <label>Text to Insert</label>
+                <textarea class="snippet-replacement dark-input" required></textarea>
+            </div>
+            <button type="button" class="remove-button" onclick="removeSnippet(this)">
+                Remove
+            </button>
+        </div>
+    </template>
 
     <script>
         function addCustomSearch() {
@@ -283,6 +334,18 @@
 
         function removeCustomSearch(button) {
             button.closest('.custom-search-item').remove();
+        }
+
+        // Nouvelle fonction pour ajouter un snippet
+        function addSnippet() {
+            const template = document.getElementById('snippetTemplate');
+            const container = document.getElementById('snippets');
+            const clone = template.content.cloneNode(true);
+            container.appendChild(clone);
+        }
+
+        function removeSnippet(button) {
+            button.closest('.snippet-item').remove();
         }
 
         document.addEventListener('DOMContentLoaded', async () => {
@@ -304,6 +367,15 @@
                     lastItem.querySelector('.search-url').value = search.url;
                     lastItem.querySelector('.search-activate').checked = search.activateSearch;
                     lastItem.querySelector('.search-allow-spaces').checked = search.allowSpaces;
+                });
+            }
+
+            if (settings.snippets && Array.isArray(settings.snippets)) {
+                settings.snippets.forEach(snippet => {
+                    addSnippet();
+                    const lastItem = document.querySelector('.snippet-item:last-child');
+                    lastItem.querySelector('.snippet-keyword').value = snippet.keyword;
+                    lastItem.querySelector('.snippet-replacement').value = snippet.replacement;
                 });
             }
         });
@@ -337,6 +409,20 @@
                 });
             });
             settings.customSearches = customSearches;
+
+            const snippets = [];
+            document.querySelectorAll('.snippet-item').forEach(item => {
+                const keyword = item.querySelector('.snippet-keyword').value.trim();
+                const replacement = item.querySelector('.snippet-replacement').value;
+                
+                if (keyword && replacement) {
+                    snippets.push({
+                        keyword,
+                        replacement
+                    });
+                }
+            });
+            settings.snippets = snippets;
             
             await window.electronAPI.saveSettings(settings);
             

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -5,6 +5,7 @@ const SalesforceMultipleIdsCommand = require('./salesforceMultipleIds');
 const CustomSearchCommand = require('./customSearch');
 const ExtractValueCommand = require('./extractValue');
 const UpdateValuesCommand = require('./updateValues');
+const SnippetsCommand = require('./snippets-command');
 
 
 /**
@@ -26,6 +27,7 @@ class CommandManager {
         this.customSearch = new CustomSearchCommand(app, settingsManager);
         this.extractValue = new ExtractValueCommand(app, settingsManager);
         this.updateValues = new UpdateValuesCommand(app, settingsManager);
+        this.snippets = new SnippetsCommand(app, settingsManager);
     }
 
     /**
@@ -40,6 +42,7 @@ class CommandManager {
         this.customSearch.setupIpc(ipcMain);
         this.extractValue.setupIpc(ipcMain);
         this.updateValues.setupIpc(ipcMain);
+        this.snippets.setupIpc(ipcMain);
     }
 
     /**
@@ -49,7 +52,7 @@ class CommandManager {
      */
     async setupShortcuts(globalShortcut) {
         globalShortcut.unregisterAll();
-    
+       
         if (await this.settings.get('openSalesforceIdActive')) {
             const shortcut = await this.settings.get('openSalesforceIdShortcut');
             if (shortcut) {
@@ -96,6 +99,13 @@ class CommandManager {
             const shortcut = await this.settings.get('updateValuesShortcut');
             if (shortcut) {
                 globalShortcut.register(shortcut, () => this.updateValues.createWindow());
+            }
+        }
+        
+        if (await this.settings.get('snippetsActive')) {
+            const shortcut = await this.settings.get('snippetsShortcut');
+            if (shortcut) {
+                globalShortcut.register(shortcut, () => this.snippets.createWindow());
             }
         }
     }

--- a/src/commands/snippets-command.js
+++ b/src/commands/snippets-command.js
@@ -1,0 +1,86 @@
+const { clipboard } = require('electron');
+const { createDarkWindow } = require('../windows/window-utils');
+const path = require('path');
+
+/**
+ * Handles text snippets operations
+ * @class
+ */
+class SnippetsCommand {
+    /**
+     * Creates a new SnippetsCommand instance
+     * @param {Electron.App} app - The main Electron application instance
+     * @param {SettingsManager} settingsManager - The settings manager instance
+     */
+    constructor(app, settingsManager) {
+        this.app = app;
+        this.settings = settingsManager;
+        this.window = null;
+    }
+
+    /**
+     * Creates and displays the snippets input window
+     * @returns {void}
+     */
+    createWindow() {
+        if (this.window) {
+            this.window.focus();
+            return;
+        }
+
+        this.window = createDarkWindow({
+            width: 250,
+            height: 110,
+            frame: false,
+            transparent: true,
+            resizable: false,
+            alwaysOnTop: true
+        });
+
+        this.window.loadFile(path.join(this.app.getAppPath(), 'src/windows/snippets-input.html'));
+        this.window.center();
+
+        this.window.on('closed', () => {
+            this.window = null;
+        });
+
+        this.window.on('blur', () => {
+            if (this.window) {
+                this.window.close();
+            }
+        });
+    }
+
+    /**
+     * Sets up IPC handlers for snippets operations
+     * @param {Electron.IpcMain} ipcMain - The Electron IPC main instance
+     */
+    setupIpc(ipcMain) {
+        ipcMain.handle('get-snippets', async () => {
+            try {
+                return await this.settings.get('snippets') || [];
+            } catch (error) {
+                console.error('Error getting snippets:', error);
+                return [];
+            }
+        });
+
+        ipcMain.handle('copy-snippet-to-clipboard', async (event, text) => {
+            try {
+                clipboard.writeText(text);
+                return true;
+            } catch (error) {
+                console.error('Error copying to clipboard:', error);
+                return false;
+            }
+        });
+
+        ipcMain.on('close-snippets', () => {
+            if (this.window) {
+                this.window.close();
+            }
+        });
+    }
+}
+
+module.exports = SnippetsCommand;

--- a/src/store-schema.js
+++ b/src/store-schema.js
@@ -42,6 +42,22 @@ module.exports = {
         type: 'string',
         default: ''
     },
+    snippets: {
+        type: 'array',
+        default: [],
+        items: {
+            type: 'object',
+            properties: {
+                keyword: { type: 'string' },
+                replacement: { type: 'string' }
+            },
+            required: ['keyword', 'replacement']
+        }
+    },
+    snippetsShortcut: {
+        type: 'string',
+        default: ''
+    },
     extractValueShortcut: {
         type: 'string',
         default: ''
@@ -75,6 +91,10 @@ module.exports = {
         default: true
     },
     updateValuesActive: {
+        type: 'boolean',
+        default: true
+    },
+    snippetsActive: {
         type: 'boolean',
         default: true
     }

--- a/src/styles/dark-input.css
+++ b/src/styles/dark-input.css
@@ -554,3 +554,60 @@ input[type="number"]::-webkit-outer-spin-button {
     border-style: solid;
     border-color: transparent #333 transparent transparent;
 }
+
+.snippets-container {
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    border: 1px solid #333;
+    border-radius: 4px;
+    padding: 1rem;
+    background-color: #1e1e1e;
+}
+
+.snippets {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 0.5rem;
+}
+
+.snippet-item {
+    display: grid;
+    grid-template-columns: 1fr 2fr auto;
+    gap: 1rem;
+    align-items: start;
+    padding: 1rem;
+    background-color: #262626;
+    border-radius: 4px;
+}
+
+.snippet-item .form-group {
+    margin: 0;
+}
+
+.snippet-item textarea {
+    min-height: 60px;
+    resize: vertical;
+}
+
+@media (max-width: 768px) {
+    .snippet-item {
+        grid-template-columns: 1fr;
+    }
+}
+
+.success-message {
+    color: #4caf50;
+    font-size: 0.9rem;
+    text-align: center;
+    margin-top: 0.5rem;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    height: 0;
+    overflow: hidden;
+}
+
+.success-message.visible {
+    opacity: 1;
+    height: auto;
+}

--- a/src/windows/snippets-input.html
+++ b/src/windows/snippets-input.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">
+    <meta name="color-scheme" content="dark">
+    <title>Text Snippets</title>
+    <link rel="stylesheet" href="../styles/dark-input.css">
+</head>
+<body class="modal-window">
+    <div class="input-container">
+        <input type="text" 
+               id="snippet-input"
+               class="dark-input"
+               placeholder="Enter snippet keyword..." 
+               list="snippet-options"
+               autocomplete="off"
+               autofocus>
+        <datalist id="snippet-options">
+        </datalist>
+        <div class="hint">
+            Press <span class="key">↵</span> to copy or <span class="key">Esc</span> to cancel
+        </div>
+        <div id="success-message" class="success-message"></div>
+    </div>
+
+    <script>
+        let snippets = [];
+
+        const input = document.getElementById('snippet-input');
+        const datalist = document.getElementById('snippet-options');
+        const successMessage = document.getElementById('success-message');
+
+        document.addEventListener('DOMContentLoaded', async () => {
+            input.focus();
+            await loadSnippets();
+        });
+
+        async function loadSnippets() {
+            try {
+                snippets = await window.electronAPI.getSnippets();
+                updateDatalist();
+            } catch (error) {
+                console.error('Error loading snippets:', error);
+            }
+        }
+
+        function updateDatalist() {
+            datalist.innerHTML = '';
+            if (snippets && snippets.length > 0) {
+                snippets.forEach(snippet => {
+                    const option = document.createElement('option');
+                    option.value = snippet.keyword;
+                    datalist.appendChild(option);
+                });
+            }
+        }
+
+        function findMatchingSnippet(keyword) {
+            if (!keyword || !snippets || snippets.length === 0) return null;
+            return snippets.find(s => s.keyword.toLowerCase() === keyword.toLowerCase());
+        }
+
+        input.addEventListener('keyup', async (event) => {
+            if (event.key === 'Enter') {
+                const keyword = input.value.trim();
+                if (!keyword) return;
+                
+                await loadSnippets();
+                
+                const snippet = findMatchingSnippet(keyword);
+                if (snippet) {
+                    await window.electronAPI.copySnippetToClipboard(snippet.replacement);
+                    
+                    successMessage.textContent = 'Copied to clipboard!';
+                    successMessage.classList.add('visible');
+                    
+                    input.disabled = true;
+                    
+                    setTimeout(() => {
+                        window.electronAPI.closeSnippets();
+                    }, 200);
+                }
+            } else if (event.key === 'Escape') {
+                window.electronAPI.closeSnippets();
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
New command that lets users create Snippets in settings. 
Users can then open the command and search for their Snippet.
Once selected, the associated message will be copied to the user's clipboard.

<img width="787" alt="settings" src="https://github.com/user-attachments/assets/68023350-413b-4698-b1b1-e7fdeec8ca6c" />
<img width="585" alt="shortcut" src="https://github.com/user-attachments/assets/25e91013-6c6f-4210-a826-2e5ea35af346" />
